### PR TITLE
Added support for running multi-job workflows

### DIFF
--- a/cli/sparklespray/io_helper.py
+++ b/cli/sparklespray/io_helper.py
@@ -139,7 +139,7 @@ class IO:
             # log.warning("Downloading %s (%s, %s)", src_url, start, end)
             return blob.download_as_string(start=start, end=end).decode("utf8")
         else:
-            assert not must, "Could not find {}".format(path)
+            assert not must, "Could not find {}".format(src_url)
             return None
 
     def put(self, src_filename, dst_url, must=True, skip_if_exists=False):

--- a/cli/sparklespray/main.py
+++ b/cli/sparklespray/main.py
@@ -586,6 +586,7 @@ def main(argv=None):
     from .submit import add_submit_cmd
     from .watch import add_watch_cmd
     from .list import add_list_cmd, add_list_nodes_cmd
+    from .workflow import add_workflow_cmd
 
     parse = argparse.ArgumentParser()
     parse.add_argument("-c","--config", default=None)
@@ -598,6 +599,7 @@ def main(argv=None):
     add_submit_cmd(subparser)
     add_list_cmd(subparser)
     add_list_nodes_cmd(subparser)
+    add_workflow_cmd(subparser)
 
     parser = subparser.add_parser(
         "validate", help="Run a series of tests to confirm the configuration is valid"

--- a/cli/sparklespray/submit.py
+++ b/cli/sparklespray/submit.py
@@ -527,6 +527,7 @@ def submit_cmd(jq: JobQueue, io: IO, cluster: Cluster, args: Any, config: Config
         parameters = [{"index": str(i)} for i in range(args.seq)]
     elif args.params is not None:
         parameters = read_csv_as_dicts(args.params)
+        assert len(parameters) > 0
     else:
         parameters = [{}]
 

--- a/cli/sparklespray/submit.py
+++ b/cli/sparklespray/submit.py
@@ -482,7 +482,6 @@ def add_submit_cmd(subparser):
     )
     parser.add_argument("command", nargs=argparse.REMAINDER)
 
-
 def submit_cmd(jq: JobQueue, io: IO, cluster: Cluster, args: Any, config: Config):
     metadata: Dict[str, str] = {}
 

--- a/cli/sparklespray/submit.py
+++ b/cli/sparklespray/submit.py
@@ -373,12 +373,7 @@ def _parse_resources(resources_str):
         spec[name] = value
     return spec
 
-
-def add_submit_cmd(subparser):
-    parser = subparser.add_parser(
-        "sub", help="Submit a command (or batch of commands) for execution"
-    )
-    parser.set_defaults(func=submit_cmd)
+def _setup_parser_for_sub_command(parser):
     parser.add_argument(
         "--machine-type",
         "-m",
@@ -481,6 +476,21 @@ def add_submit_cmd(subparser):
         action="store_true",
     )
     parser.add_argument("command", nargs=argparse.REMAINDER)
+
+def add_submit_cmd(subparser):
+    parser = subparser.add_parser(
+        "sub", help="Submit a command (or batch of commands) for execution"
+    )
+    parser.set_defaults(func=submit_cmd)
+    _setup_parser_for_sub_command(parser)
+
+def construct_submit_cmd_args(unparsed_args: List[str]):
+    # create a temp parser for converting the unparsed_args to an instance of args that `submit_cmd` will
+    # accept
+    parser = argparse.ArgumentParser()
+    _setup_parser_for_sub_command(parser)
+    args = parser.parse_args(unparsed_args)
+    return args
 
 def submit_cmd(jq: JobQueue, io: IO, cluster: Cluster, args: Any, config: Config):
     metadata: Dict[str, str] = {}

--- a/cli/sparklespray/workflow.py
+++ b/cli/sparklespray/workflow.py
@@ -3,30 +3,38 @@ import os
 import csv
 import subprocess
 from typing import Dict, Any, List, Optional
-from dataclasses import dataclass
+from pydantic import BaseModel, Field, validator, root_validator
 from .job_queue import JobQueue
 from .io_helper import IO
 from .cluster_service import Cluster
 from .log import log
 from . import txtui
 
-@dataclass
-class WorkflowStep:
+class WorkflowStep(BaseModel):
     """Represents a single step in a workflow."""
     command: List[str]
     run_local: bool = False
     image: Optional[str] = None
     parameters_csv: Optional[str] = None
-
-class WorkflowDefinition:
-    """Represents a workflow definition loaded from a JSON file."""
     
-    def __init__(self, workflow_data: Dict[str, Any]):
-        self.workflow_data = workflow_data
-        self.steps = []
-        self.validate()
-        self._parse_steps()
-        
+    @validator('command')
+    def validate_command(cls, v):
+        if not v:
+            raise ValueError("Command cannot be empty")
+        if not all(isinstance(cmd, str) for cmd in v):
+            raise ValueError("All command parts must be strings")
+        return v
+    
+    @validator('parameters_csv')
+    def validate_parameters_csv(cls, v):
+        if v is not None and not os.path.exists(v):
+            raise ValueError(f"Parameters CSV file not found: {v}")
+        return v
+
+class WorkflowDefinition(BaseModel):
+    """Represents a workflow definition loaded from a JSON file."""
+    steps: List[WorkflowStep]
+    
     @classmethod
     def from_file(cls, file_path: str) -> 'WorkflowDefinition':
         """Load a workflow definition from a JSON file."""
@@ -36,58 +44,9 @@ class WorkflowDefinition:
         with open(file_path, 'r') as f:
             try:
                 workflow_data = json.load(f)
-                return cls(workflow_data)
+                return cls.parse_obj(workflow_data)
             except json.JSONDecodeError:
                 raise ValueError(f"Invalid JSON in workflow definition file: {file_path}")
-    
-    def validate(self) -> None:
-        """Validate the workflow definition."""
-        if not isinstance(self.workflow_data, dict):
-            raise ValueError("Workflow definition must be a JSON object")
-            
-        if 'steps' not in self.workflow_data:
-            raise ValueError("Workflow definition must contain a 'steps' array")
-            
-        if not isinstance(self.workflow_data['steps'], list):
-            raise ValueError("'steps' must be an array")
-            
-        for i, step in enumerate(self.workflow_data['steps']):
-            if not isinstance(step, dict):
-                raise ValueError(f"Step {i} must be an object")
-                
-            if 'command' not in step:
-                raise ValueError(f"Step {i} must contain a 'command' array")
-                
-            if not isinstance(step['command'], list):
-                raise ValueError(f"'command' in step {i} must be an array of strings")
-                
-            for cmd_part in step['command']:
-                if not isinstance(cmd_part, str):
-                    raise ValueError(f"Command parts in step {i} must be strings")
-                    
-            if 'run_local' in step and not isinstance(step['run_local'], bool):
-                raise ValueError(f"'run_local' in step {i} must be a boolean")
-                
-            if 'image' in step and step['image'] is not None and not isinstance(step['image'], str):
-                raise ValueError(f"'image' in step {i} must be a string or null")
-                
-            if 'parameters_csv' in step and step['parameters_csv'] is not None:
-                if not isinstance(step['parameters_csv'], str):
-                    raise ValueError(f"'parameters_csv' in step {i} must be a string or null")
-                if not os.path.exists(step['parameters_csv']):
-                    raise ValueError(f"Parameters CSV file not found: {step['parameters_csv']}")
-    
-    def _parse_steps(self) -> None:
-        """Parse the steps from the workflow definition."""
-        self.steps = []
-        for step_data in self.workflow_data.get('steps', []):
-            step = WorkflowStep(
-                command=step_data['command'],
-                run_local=step_data.get('run_local', False),
-                image=step_data.get('image'),
-                parameters_csv=step_data.get('parameters_csv')
-            )
-            self.steps.append(step)
     
     def get_steps(self) -> List[WorkflowStep]:
         """Get the list of workflow steps."""

--- a/cli/sparklespray/workflow.py
+++ b/cli/sparklespray/workflow.py
@@ -229,7 +229,7 @@ def workflow_run_cmd(jq: JobQueue, io: IO, cluster: Cluster, args):
             return io._get_url_prefix()
     
     parameters = {}
-    if hasattr(args, 'parameter') and args.parameter:
+    if args.parameter:
         parameters.update(dict(args.parameter))
 
     return run_workflow(SparklesImpl(), args.job_name, args.workflow_def, args.retry, parameters)

--- a/cli/sparklespray/workflow.py
+++ b/cli/sparklespray/workflow.py
@@ -1,19 +1,31 @@
 import json
 import os
-from typing import Dict, Any, List
-import logging
+import csv
+import subprocess
+from typing import Dict, Any, List, Optional
+from dataclasses import dataclass
 from .job_queue import JobQueue
 from .io_helper import IO
 from .cluster_service import Cluster
 from .log import log
 from . import txtui
 
+@dataclass
+class WorkflowStep:
+    """Represents a single step in a workflow."""
+    command: List[str]
+    run_local: bool = False
+    image: Optional[str] = None
+    parameters_csv: Optional[str] = None
+
 class WorkflowDefinition:
     """Represents a workflow definition loaded from a JSON file."""
     
     def __init__(self, workflow_data: Dict[str, Any]):
         self.workflow_data = workflow_data
+        self.steps = []
         self.validate()
+        self._parse_steps()
         
     @classmethod
     def from_file(cls, file_path: str) -> 'WorkflowDefinition':
@@ -30,13 +42,85 @@ class WorkflowDefinition:
     
     def validate(self) -> None:
         """Validate the workflow definition."""
-        # Basic validation - can be expanded based on workflow requirements
         if not isinstance(self.workflow_data, dict):
             raise ValueError("Workflow definition must be a JSON object")
-        
-        # Add more validation as needed for your workflow structure
-        # For example, checking required fields, validating task definitions, etc.
+            
+        if 'steps' not in self.workflow_data:
+            raise ValueError("Workflow definition must contain a 'steps' array")
+            
+        if not isinstance(self.workflow_data['steps'], list):
+            raise ValueError("'steps' must be an array")
+            
+        for i, step in enumerate(self.workflow_data['steps']):
+            if not isinstance(step, dict):
+                raise ValueError(f"Step {i} must be an object")
+                
+            if 'command' not in step:
+                raise ValueError(f"Step {i} must contain a 'command' array")
+                
+            if not isinstance(step['command'], list):
+                raise ValueError(f"'command' in step {i} must be an array of strings")
+                
+            for cmd_part in step['command']:
+                if not isinstance(cmd_part, str):
+                    raise ValueError(f"Command parts in step {i} must be strings")
+                    
+            if 'run_local' in step and not isinstance(step['run_local'], bool):
+                raise ValueError(f"'run_local' in step {i} must be a boolean")
+                
+            if 'image' in step and step['image'] is not None and not isinstance(step['image'], str):
+                raise ValueError(f"'image' in step {i} must be a string or null")
+                
+            if 'parameters_csv' in step and step['parameters_csv'] is not None:
+                if not isinstance(step['parameters_csv'], str):
+                    raise ValueError(f"'parameters_csv' in step {i} must be a string or null")
+                if not os.path.exists(step['parameters_csv']):
+                    raise ValueError(f"Parameters CSV file not found: {step['parameters_csv']}")
+    
+    def _parse_steps(self) -> None:
+        """Parse the steps from the workflow definition."""
+        self.steps = []
+        for step_data in self.workflow_data.get('steps', []):
+            step = WorkflowStep(
+                command=step_data['command'],
+                run_local=step_data.get('run_local', False),
+                image=step_data.get('image'),
+                parameters_csv=step_data.get('parameters_csv')
+            )
+            self.steps.append(step)
+    
+    def get_steps(self) -> List[WorkflowStep]:
+        """Get the list of workflow steps."""
+        return self.steps
 
+
+def _run_local_command(command: List[str]) -> int:
+    """Run a command locally and return the exit code."""
+    log.info(f"Running local command: {' '.join(command)}")
+    txtui.user_print(f"Running local command: {' '.join(command)}")
+    
+    try:
+        result = subprocess.run(command, check=False)
+        return result.returncode
+    except Exception as e:
+        log.error(f"Error running local command: {str(e)}")
+        return 1
+
+def _load_parameters_from_csv(csv_path: str) -> List[Dict[str, str]]:
+    """Load parameters from a CSV file."""
+    if not csv_path:
+        return [{}]  # Return a single empty parameter set if no CSV
+        
+    parameters = []
+    with open(csv_path, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            parameters.append(dict(row))
+    
+    if not parameters:
+        return [{}]  # Return a single empty parameter set if CSV is empty
+        
+    return parameters
 
 def run_workflow(jq: JobQueue, io: IO, cluster: Cluster, job_name: str, workflow_def_path: str) -> None:
     """
@@ -57,15 +141,37 @@ def run_workflow(jq: JobQueue, io: IO, cluster: Cluster, job_name: str, workflow
         log.info(f"Starting workflow execution for job: {job_name}")
         txtui.user_print(f"Starting workflow: {job_name}")
         
-        # TODO: Implement the actual workflow execution logic
-        # This would involve:
-        # 1. Parsing the workflow definition
-        # 2. Creating and submitting jobs based on the workflow
-        # 3. Handling dependencies between workflow steps
-        # 4. Monitoring execution progress
+        # Process each step in the workflow
+        for i, step in enumerate(workflow.get_steps()):
+            step_num = i + 1
+            txtui.user_print(f"Executing step {step_num}/{len(workflow.get_steps())}")
+            
+            if step.run_local:
+                # Run the command locally
+                exit_code = _run_local_command(step.command)
+                if exit_code != 0:
+                    raise RuntimeError(f"Local command in step {step_num} failed with exit code {exit_code}")
+            else:
+                # This is a distributed job
+                parameters = _load_parameters_from_csv(step.parameters_csv)
+                
+                # TODO: Submit the job to the cluster
+                # This would involve:
+                # 1. Creating a job with the specified command
+                # 2. Setting the docker image if specified
+                # 3. Submitting the job with the parameters
+                
+                txtui.user_print(f"Would submit distributed job for step {step_num} with {len(parameters)} parameter sets")
+                txtui.user_print(f"  Command: {' '.join(step.command)}")
+                if step.image:
+                    txtui.user_print(f"  Image: {step.image}")
+                else:
+                    txtui.user_print("  Using default image")
+                
+                # For now, just log that we would submit a job
+                log.info(f"Would submit job for step {step_num} with command: {step.command}")
         
-        txtui.user_print(f"Workflow definition loaded successfully from: {workflow_def_path}")
-        txtui.user_print("Workflow execution not yet implemented - this is a placeholder")
+        txtui.user_print(f"Workflow execution completed successfully")
         
     except Exception as e:
         log.error(f"Error running workflow: {str(e)}")

--- a/cli/sparklespray/workflow.py
+++ b/cli/sparklespray/workflow.py
@@ -228,8 +228,8 @@ def workflow_run_cmd(jq: JobQueue, io: IO, cluster: Cluster, args):
             # Return the base path for jobs
             return io._get_url_prefix()
     
-    parameters={}
-    if args.parameter:
-        parameters.update(args.parameter)
+    parameters = {}
+    if hasattr(args, 'parameter') and args.parameter:
+        parameters.update(dict(args.parameter))
 
     return run_workflow(SparklesImpl(), args.job_name, args.workflow_def, args.retry, parameters)

--- a/cli/sparklespray/workflow.py
+++ b/cli/sparklespray/workflow.py
@@ -1,0 +1,88 @@
+import json
+import os
+from typing import Dict, Any, List
+import logging
+from .job_queue import JobQueue
+from .io_helper import IO
+from .cluster_service import Cluster
+from .log import log
+from . import txtui
+
+class WorkflowDefinition:
+    """Represents a workflow definition loaded from a JSON file."""
+    
+    def __init__(self, workflow_data: Dict[str, Any]):
+        self.workflow_data = workflow_data
+        self.validate()
+        
+    @classmethod
+    def from_file(cls, file_path: str) -> 'WorkflowDefinition':
+        """Load a workflow definition from a JSON file."""
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"Workflow definition file not found: {file_path}")
+        
+        with open(file_path, 'r') as f:
+            try:
+                workflow_data = json.load(f)
+                return cls(workflow_data)
+            except json.JSONDecodeError:
+                raise ValueError(f"Invalid JSON in workflow definition file: {file_path}")
+    
+    def validate(self) -> None:
+        """Validate the workflow definition."""
+        # Basic validation - can be expanded based on workflow requirements
+        if not isinstance(self.workflow_data, dict):
+            raise ValueError("Workflow definition must be a JSON object")
+        
+        # Add more validation as needed for your workflow structure
+        # For example, checking required fields, validating task definitions, etc.
+
+
+def run_workflow(jq: JobQueue, io: IO, cluster: Cluster, job_name: str, workflow_def_path: str) -> None:
+    """
+    Run a workflow defined in a JSON file.
+    
+    Args:
+        jq: JobQueue instance
+        io: IO helper instance
+        cluster: Cluster instance
+        job_name: Name to use for the job
+        workflow_def_path: Path to the JSON file containing the workflow definition
+    """
+    try:
+        # Load and validate the workflow definition
+        workflow = WorkflowDefinition.from_file(workflow_def_path)
+        
+        # Log the start of workflow execution
+        log.info(f"Starting workflow execution for job: {job_name}")
+        txtui.user_print(f"Starting workflow: {job_name}")
+        
+        # TODO: Implement the actual workflow execution logic
+        # This would involve:
+        # 1. Parsing the workflow definition
+        # 2. Creating and submitting jobs based on the workflow
+        # 3. Handling dependencies between workflow steps
+        # 4. Monitoring execution progress
+        
+        txtui.user_print(f"Workflow definition loaded successfully from: {workflow_def_path}")
+        txtui.user_print("Workflow execution not yet implemented - this is a placeholder")
+        
+    except Exception as e:
+        log.error(f"Error running workflow: {str(e)}")
+        txtui.user_print(f"Error: {str(e)}")
+        raise
+
+def add_workflow_cmd(subparser):
+    """Add the workflow command to the CLI parser."""
+    parser = subparser.add_parser("workflow", help="Manage and run workflows")
+    workflow_subparser = parser.add_subparsers(dest="workflow_cmd")
+    
+    # Add the 'run' subcommand
+    run_parser = workflow_subparser.add_parser("run", help="Run a workflow")
+    run_parser.add_argument("job_name", help="Name to use for the job")
+    run_parser.add_argument("workflow_def", help="Path to a JSON file containing the workflow definition")
+    run_parser.set_defaults(func=workflow_run_cmd)
+
+def workflow_run_cmd(jq: JobQueue, io: IO, cluster: Cluster, args):
+    """Command handler for 'workflow run'."""
+    return run_workflow(jq, io, cluster, args.job_name, args.workflow_def)

--- a/cli/sparklespray/workflow.py
+++ b/cli/sparklespray/workflow.py
@@ -9,6 +9,7 @@ from .io_helper import IO
 from .cluster_service import Cluster
 from .log import log
 from . import txtui
+from .task_store import STATUS_FAILED
 
 class WorkflowStep(BaseModel):
     """Represents a single step in a workflow."""

--- a/cli/sparklespray/workflow.py
+++ b/cli/sparklespray/workflow.py
@@ -92,6 +92,11 @@ def run_workflow(sparkles: SparklesInterface, job_name: str, workflow_def_path: 
         txtui.user_print(f"Starting workflow: {job_name}")
 
         variables = {}
+        def _get_var(name):
+            if name.startswith("parameter."):
+                return "{"+name[len("parameter."):]+"}"
+            return variables[name]
+
         def _expand_template(value):
             pass
 

--- a/cli/sparklespray/workflow.py
+++ b/cli/sparklespray/workflow.py
@@ -175,7 +175,7 @@ def run_workflow(sparkles: SparklesInterface, job_name: str, workflow_def_path: 
             sparkles.wait_for_completion(sub_job_name)
             txtui.user_print(f"Executing step {step_num}/{len(workflow.steps)} completed")
             variables["prev_job_name"] = job_name
-            variables["prev_job_path"] = job_path
+            variables["prev_job_path"] = f"{job_path_prefix}/{job_name}"
         
         txtui.user_print(f"Workflow execution completed successfully")
         

--- a/cli/sparklespray/workflow.py
+++ b/cli/sparklespray/workflow.py
@@ -72,7 +72,7 @@ class SparklesInterface:
         raise NotImplementedError()
     def start(self, name: str, command: List[str], params: List[Dict[str,str]], image: Optional[str]):
         raise NotImplementedError()
-    def get_job_path_prefix() -> str:
+    def get_job_path_prefix(self) -> str:
         raise NotImplementedError()
 
 
@@ -222,5 +222,9 @@ def workflow_run_cmd(jq: JobQueue, io: IO, cluster: Cluster, args):
             from .submit import submit
             submit(jq, io, cluster, name, command, parameters=params, 
                    docker_image=image, wait_for_completion=False)
+                   
+        def get_job_path_prefix(self) -> str:
+            # Return the base path for jobs
+            return io._get_url_prefix()
     
     return run_workflow(SparklesImpl(), args.job_name, args.workflow_def, args.retry)

--- a/cli/tests/sparklespray/workflow_test.py
+++ b/cli/tests/sparklespray/workflow_test.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import os
 import tempfile
 import json
-from sparklespray.workflow import run_workflow, SparklesInterface, WorkflowDefinition
+from sparklespray.workflow import run_workflow, SparklesInterface, WorkflowDefinition, WorkflowRunArgs
 
 class MockSparkles(SparklesInterface):
     def __init__(self):
@@ -12,6 +12,7 @@ class MockSparkles(SparklesInterface):
         self.clear_failed_calls = []
         self.wait_for_completion_calls = []
         self.start_calls = []
+        self.blobs = {}
         
     def job_exists(self, name: str) -> bool:
         self.job_exists_calls.append(name)
@@ -23,12 +24,19 @@ class MockSparkles(SparklesInterface):
     def wait_for_completion(self, name: str):
         self.wait_for_completion_calls.append(name)
     
-    def start(self, name: str, command, params, image, uploads):
-        self.start_calls.append((name, command, params, image, uploads))
+    def start(self, name: str, command, params, image, uploads, machine_type):
+        self.start_calls.append((name, command, params, image, uploads, machine_type))
         self.jobs[name] = True
         
     def get_job_path_prefix(self) -> str:
         return "/path/to/jobs"
+    
+    def read_as_bytes(self, path):
+        if path.startswith("gs://"):
+            return self.blobs[path]
+        else:
+            with open(path, "rb") as fd:
+                return fd.read()
 
 def create_workflow_file(filename, content):
     with open(filename, 'w') as f:
@@ -51,11 +59,11 @@ def test_run_workflow_basic(tmpdir):
     job_name = "test-job"
     
     # Run the workflow
-    run_workflow(sparkles, job_name, workflow_path, False, {})
+    run_workflow(sparkles, job_name, workflow_path, WorkflowRunArgs())
     
     # Verify the expected calls were made
     assert sparkles.job_exists_calls == ["test-job-1"]
-    assert sparkles.start_calls == [("test-job-1", ["echo", "Hello World"], [{}], None, [] ), ]
+    assert sparkles.start_calls == [("test-job-1", ["echo", "Hello World"],  [{}], None, [], None ), ]
     assert sparkles.wait_for_completion_calls == ["test-job-1"]
     assert len(sparkles.clear_failed_calls) == 0
 
@@ -83,13 +91,13 @@ def test_run_workflow_with_retry(tmpdir):
     sparkles.jobs["test-job-1"] = True
     job_name = "test-job"
     
-    # Run the workflow with retry flag
-    run_workflow(sparkles, job_name, workflow_path, True, {})
+    # Run the workflow with retry flag¬129
+    run_workflow(sparkles, job_name, workflow_path, WorkflowRunArgs(retry=True))
     
     # Verify the expected calls were made
     assert sparkles.job_exists_calls == ["test-job-1", "test-job-2"]
     assert sparkles.clear_failed_calls == ["test-job-1"]
-    assert sparkles.start_calls == [("test-job-2", ["echo", "Step 2"], [{}], "python:3.9", [])]
+    assert sparkles.start_calls == [("test-job-2", ["echo", "Step 2"], [{}], 'python:3.9', [], None)]
     assert sparkles.wait_for_completion_calls == ["test-job-1", "test-job-2"]
 
 def test_run_workflow_with_parameters(tmpdir):
@@ -113,20 +121,21 @@ def test_run_workflow_with_parameters(tmpdir):
     create_workflow_file(workflow_path, workflow_def)
 
     sparkles = MockSparkles()
-    sparkles.get_job_path_prefix = lambda: "/path/to/jobs"
+    sparkles.get_job_path_prefix = lambda: "gs://path/to/jobs"
     job_name = "test-job"
     
     # Run the workflow
-    run_workflow(sparkles, job_name, workflow_path, False, {})
+    run_workflow(sparkles, job_name, workflow_path, WorkflowRunArgs())
     
     # Verify the expected calls were made
     assert sparkles.job_exists_calls == ["test-job-1"]
     assert len(sparkles.start_calls) == 1
-    name, command, params, image, uploads = sparkles.start_calls[0]
+    name, command, params, image, uploads, machine_type = sparkles.start_calls[0]
     assert name == "test-job-1"
-    assert command == ["process", "test-job", "/path/to/jobs/test-job"]
+    assert command == ["process", "test-job", "gs://path/to/jobs/test-job"]
     assert len(params) == 2
     assert params[0] == {"name": "item1", "value": "100"}
     assert params[1] == {"name": "item2", "value": "200"}
     assert image is None
     assert uploads == []
+    assert machine_type is None

--- a/cli/tests/sparklespray/workflow_test.py
+++ b/cli/tests/sparklespray/workflow_test.py
@@ -1,0 +1,167 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import os
+import tempfile
+import json
+from sparklespray.workflow import run_workflow, SparklesInterface, WorkflowDefinition
+
+class MockSparkles(SparklesInterface):
+    def __init__(self):
+        self.jobs = {}
+        self.job_exists_calls = []
+        self.clear_failed_calls = []
+        self.wait_for_completion_calls = []
+        self.start_calls = []
+        
+    def job_exists(self, name: str) -> bool:
+        self.job_exists_calls.append(name)
+        return name in self.jobs
+    
+    def clear_failed(self, name: str):
+        self.clear_failed_calls.append(name)
+    
+    def wait_for_completion(self, name: str):
+        self.wait_for_completion_calls.append(name)
+    
+    def start(self, name: str, command, params, image):
+        self.start_calls.append((name, command, params, image))
+        self.jobs[name] = True
+
+def create_workflow_file(content):
+    fd, path = tempfile.mkstemp(suffix='.json')
+    with os.fdopen(fd, 'w') as f:
+        f.write(json.dumps(content))
+    return path
+
+def test_run_workflow_basic():
+    # Create a simple workflow definition
+    workflow_def = {
+        "steps": [
+            {
+                "command": ["echo", "Hello World"],
+                "run_local": False
+            }
+        ]
+    }
+    
+    workflow_path = create_workflow_file(workflow_def)
+    try:
+        sparkles = MockSparkles()
+        job_name = "test-job"
+        
+        # Run the workflow
+        run_workflow(sparkles, job_name, workflow_path, False)
+        
+        # Verify the expected calls were made
+        assert sparkles.job_exists_calls == ["test-job-1"]
+        assert sparkles.start_calls == [("test-job-1", ["echo", "Hello World"], [{}], None)]
+        assert sparkles.wait_for_completion_calls == ["test-job-1"]
+        assert len(sparkles.clear_failed_calls) == 0
+    finally:
+        os.unlink(workflow_path)
+
+def test_run_workflow_with_retry():
+    # Create a workflow definition
+    workflow_def = {
+        "steps": [
+            {
+                "command": ["echo", "Step 1"],
+                "run_local": False
+            },
+            {
+                "command": ["echo", "Step 2"],
+                "run_local": False,
+                "image": "python:3.9"
+            }
+        ]
+    }
+    
+    workflow_path = create_workflow_file(workflow_def)
+    try:
+        sparkles = MockSparkles()
+        # Pre-populate a job to simulate an existing job
+        sparkles.jobs["test-job-1"] = True
+        job_name = "test-job"
+        
+        # Run the workflow with retry flag
+        run_workflow(sparkles, job_name, workflow_path, True)
+        
+        # Verify the expected calls were made
+        assert sparkles.job_exists_calls == ["test-job-1", "test-job-2"]
+        assert sparkles.clear_failed_calls == ["test-job-1"]
+        assert sparkles.start_calls == [("test-job-2", ["echo", "Step 2"], [{}], "python:3.9")]
+        assert sparkles.wait_for_completion_calls == ["test-job-1", "test-job-2"]
+    finally:
+        os.unlink(workflow_path)
+
+def test_run_workflow_with_parameters():
+    # Create a CSV file with parameters
+    fd, params_path = tempfile.mkstemp(suffix='.csv')
+    with os.fdopen(fd, 'w') as f:
+        f.write("name,value\nitem1,100\nitem2,200\n")
+    
+    # Create a workflow definition that uses the parameters
+    workflow_def = {
+        "steps": [
+            {
+                "command": ["process", "data"],
+                "run_local": False,
+                "parameters_csv": params_path
+            }
+        ]
+    }
+    
+    workflow_path = create_workflow_file(workflow_def)
+    try:
+        sparkles = MockSparkles()
+        job_name = "test-job"
+        
+        # Run the workflow
+        run_workflow(sparkles, job_name, workflow_path, False)
+        
+        # Verify the expected calls were made
+        assert sparkles.job_exists_calls == ["test-job-1"]
+        assert len(sparkles.start_calls) == 1
+        name, command, params, image = sparkles.start_calls[0]
+        assert name == "test-job-1"
+        assert command == ["process", "data"]
+        assert len(params) == 2
+        assert params[0] == {"name": "item1", "value": "100"}
+        assert params[1] == {"name": "item2", "value": "200"}
+        assert image is None
+    finally:
+        os.unlink(workflow_path)
+        os.unlink(params_path)
+
+def test_run_workflow_with_variable_expansion():
+    # Create a workflow definition with variables to expand
+    workflow_def = {
+        "steps": [
+            {
+                "command": ["echo", "First step"],
+                "run_local": False
+            },
+            {
+                "command": ["echo", "{step1_output}"],
+                "run_local": False
+            }
+        ]
+    }
+    
+    workflow_path = create_workflow_file(workflow_def)
+    try:
+        sparkles = MockSparkles()
+        job_name = "test-job"
+        
+        # Mock the _get_var function to return a value for step1_output
+        with patch('sparklespray.workflow._expand_template', side_effect=lambda val, _: val.replace("{step1_output}", "expanded value")):
+            # Run the workflow
+            run_workflow(sparkles, job_name, workflow_path, False)
+        
+        # Verify the expected calls were made
+        assert sparkles.job_exists_calls == ["test-job-1", "test-job-2"]
+        assert len(sparkles.start_calls) == 2
+        assert sparkles.start_calls[0][1] == ["echo", "First step"]
+        assert sparkles.start_calls[1][1] == ["echo", "expanded value"]
+    finally:
+        os.unlink(workflow_path)

--- a/cli/tests/sparklespray/workflow_test.py
+++ b/cli/tests/sparklespray/workflow_test.py
@@ -51,7 +51,7 @@ def test_run_workflow_basic(tmpdir):
     job_name = "test-job"
     
     # Run the workflow
-    run_workflow(sparkles, job_name, workflow_path, False)
+    run_workflow(sparkles, job_name, workflow_path, False, {})
     
     # Verify the expected calls were made
     assert sparkles.job_exists_calls == ["test-job-1"]
@@ -84,7 +84,7 @@ def test_run_workflow_with_retry(tmpdir):
     job_name = "test-job"
     
     # Run the workflow with retry flag
-    run_workflow(sparkles, job_name, workflow_path, True)
+    run_workflow(sparkles, job_name, workflow_path, True, {})
     
     # Verify the expected calls were made
     assert sparkles.job_exists_calls == ["test-job-1", "test-job-2"]
@@ -117,7 +117,7 @@ def test_run_workflow_with_parameters(tmpdir):
     job_name = "test-job"
     
     # Run the workflow
-    run_workflow(sparkles, job_name, workflow_path, False)
+    run_workflow(sparkles, job_name, workflow_path, False, {})
     
     # Verify the expected calls were made
     assert sparkles.job_exists_calls == ["test-job-1"]

--- a/cli/tests/sparklespray/workflow_test.py
+++ b/cli/tests/sparklespray/workflow_test.py
@@ -23,7 +23,7 @@ class MockSparkles(SparklesInterface):
     def wait_for_completion(self, name: str):
         self.wait_for_completion_calls.append(name)
     
-    def start(self, name: str, command, params, image, uploads=None):
+    def start(self, name: str, command, params, image, uploads):
         self.start_calls.append((name, command, params, image, uploads))
         self.jobs[name] = True
         
@@ -55,7 +55,7 @@ def test_run_workflow_basic(tmpdir):
     
     # Verify the expected calls were made
     assert sparkles.job_exists_calls == ["test-job-1"]
-    assert sparkles.start_calls == [("test-job-1", ["echo", "Hello World"], [{}], None)]
+    assert sparkles.start_calls == [("test-job-1", ["echo", "Hello World"], [{}], None, [] ), ]
     assert sparkles.wait_for_completion_calls == ["test-job-1"]
     assert len(sparkles.clear_failed_calls) == 0
 
@@ -89,7 +89,7 @@ def test_run_workflow_with_retry(tmpdir):
     # Verify the expected calls were made
     assert sparkles.job_exists_calls == ["test-job-1", "test-job-2"]
     assert sparkles.clear_failed_calls == ["test-job-1"]
-    assert sparkles.start_calls == [("test-job-2", ["echo", "Step 2"], [{}], "python:3.9")]
+    assert sparkles.start_calls == [("test-job-2", ["echo", "Step 2"], [{}], "python:3.9", [])]
     assert sparkles.wait_for_completion_calls == ["test-job-1", "test-job-2"]
 
 def test_run_workflow_with_parameters(tmpdir):
@@ -122,10 +122,11 @@ def test_run_workflow_with_parameters(tmpdir):
     # Verify the expected calls were made
     assert sparkles.job_exists_calls == ["test-job-1"]
     assert len(sparkles.start_calls) == 1
-    name, command, params, image = sparkles.start_calls[0]
+    name, command, params, image, uploads = sparkles.start_calls[0]
     assert name == "test-job-1"
     assert command == ["process", "test-job", "/path/to/jobs/test-job"]
     assert len(params) == 2
     assert params[0] == {"name": "item1", "value": "100"}
     assert params[1] == {"name": "item2", "value": "200"}
     assert image is None
+    assert uploads == []

--- a/cli/tests/sparklespray/workflow_test.py
+++ b/cli/tests/sparklespray/workflow_test.py
@@ -39,7 +39,6 @@ def test_run_workflow_basic():
         "steps": [
             {
                 "command": ["echo", "Hello World"],
-                "run_local": False
             }
         ]
     }
@@ -139,11 +138,9 @@ def test_run_workflow_with_variable_expansion():
         "steps": [
             {
                 "command": ["echo", "First step"],
-                "run_local": False
             },
             {
                 "command": ["echo", "{step1_output}"],
-                "run_local": False
             }
         ]
     }

--- a/cli/tests/sparklespray/workflow_test.py
+++ b/cli/tests/sparklespray/workflow_test.py
@@ -23,8 +23,8 @@ class MockSparkles(SparklesInterface):
     def wait_for_completion(self, name: str):
         self.wait_for_completion_calls.append(name)
     
-    def start(self, name: str, command, params, image):
-        self.start_calls.append((name, command, params, image))
+    def start(self, name: str, command, params, image, uploads=None):
+        self.start_calls.append((name, command, params, image, uploads))
         self.jobs[name] = True
         
     def get_job_path_prefix(self) -> str:

--- a/cli/tests/sparklespray/workflow_test.py
+++ b/cli/tests/sparklespray/workflow_test.py
@@ -30,13 +30,11 @@ class MockSparkles(SparklesInterface):
     def get_job_path_prefix(self) -> str:
         return "/path/to/jobs"
 
-def create_workflow_file(content):
-    fd, path = tempfile.mkstemp(suffix='.json')
-    with os.fdopen(fd, 'w') as f:
+def create_workflow_file(filename, content):
+    with open(filename, 'w') as f:
         f.write(json.dumps(content))
-    return path
 
-def test_run_workflow_basic():
+def test_run_workflow_basic(tmpdir):
     # Create a simple workflow definition
     workflow_def = {
         "steps": [
@@ -46,23 +44,22 @@ def test_run_workflow_basic():
         ]
     }
     
-    workflow_path = create_workflow_file(workflow_def)
-    try:
-        sparkles = MockSparkles()
-        job_name = "test-job"
-        
-        # Run the workflow
-        run_workflow(sparkles, job_name, workflow_path, False)
-        
-        # Verify the expected calls were made
-        assert sparkles.job_exists_calls == ["test-job-1"]
-        assert sparkles.start_calls == [("test-job-1", ["echo", "Hello World"], [{}], None)]
-        assert sparkles.wait_for_completion_calls == ["test-job-1"]
-        assert len(sparkles.clear_failed_calls) == 0
-    finally:
-        os.unlink(workflow_path)
+    workflow_path = str(tmpdir.join("workflow.json"))
+    create_workflow_file(workflow_path, workflow_def)
 
-def test_run_workflow_with_retry():
+    sparkles = MockSparkles()
+    job_name = "test-job"
+    
+    # Run the workflow
+    run_workflow(sparkles, job_name, workflow_path, False)
+    
+    # Verify the expected calls were made
+    assert sparkles.job_exists_calls == ["test-job-1"]
+    assert sparkles.start_calls == [("test-job-1", ["echo", "Hello World"], [{}], None)]
+    assert sparkles.wait_for_completion_calls == ["test-job-1"]
+    assert len(sparkles.clear_failed_calls) == 0
+
+def test_run_workflow_with_retry(tmpdir):
     # Create a workflow definition
     workflow_def = {
         "steps": [
@@ -78,28 +75,27 @@ def test_run_workflow_with_retry():
         ]
     }
     
-    workflow_path = create_workflow_file(workflow_def)
-    try:
-        sparkles = MockSparkles()
-        # Pre-populate a job to simulate an existing job
-        sparkles.jobs["test-job-1"] = True
-        job_name = "test-job"
-        
-        # Run the workflow with retry flag
-        run_workflow(sparkles, job_name, workflow_path, True)
-        
-        # Verify the expected calls were made
-        assert sparkles.job_exists_calls == ["test-job-1", "test-job-2"]
-        assert sparkles.clear_failed_calls == ["test-job-1"]
-        assert sparkles.start_calls == [("test-job-2", ["echo", "Step 2"], [{}], "python:3.9")]
-        assert sparkles.wait_for_completion_calls == ["test-job-1", "test-job-2"]
-    finally:
-        os.unlink(workflow_path)
+    workflow_path = str(tmpdir.join("workflow.json"))
+    create_workflow_file(workflow_path, workflow_def)
 
-def test_run_workflow_with_parameters():
+    sparkles = MockSparkles()
+    # Pre-populate a job to simulate an existing job
+    sparkles.jobs["test-job-1"] = True
+    job_name = "test-job"
+    
+    # Run the workflow with retry flag
+    run_workflow(sparkles, job_name, workflow_path, True)
+    
+    # Verify the expected calls were made
+    assert sparkles.job_exists_calls == ["test-job-1", "test-job-2"]
+    assert sparkles.clear_failed_calls == ["test-job-1"]
+    assert sparkles.start_calls == [("test-job-2", ["echo", "Step 2"], [{}], "python:3.9")]
+    assert sparkles.wait_for_completion_calls == ["test-job-1", "test-job-2"]
+
+def test_run_workflow_with_parameters(tmpdir):
     # Create a CSV file with parameters
-    fd, params_path = tempfile.mkstemp(suffix='.csv')
-    with os.fdopen(fd, 'w') as f:
+    params_path = str(tmpdir.join("params.csv"))
+    with open(params_path, 'w') as f:
         f.write("name,value\nitem1,100\nitem2,200\n")
     
     # Create a workflow definition that uses the parameters and automatic variables
@@ -113,30 +109,28 @@ def test_run_workflow_with_parameters():
         ]
     }
     
-    workflow_path = create_workflow_file(workflow_def)
-    try:
-        sparkles = MockSparkles()
-        sparkles.get_job_path_prefix = lambda: "/path/to/jobs"
-        job_name = "test-job"
-        
-        # Run the workflow
-        run_workflow(sparkles, job_name, workflow_path, False)
-        
-        # Verify the expected calls were made
-        assert sparkles.job_exists_calls == ["test-job-1"]
-        assert len(sparkles.start_calls) == 1
-        name, command, params, image = sparkles.start_calls[0]
-        assert name == "test-job-1"
-        assert command == ["process", "test-job", "/path/to/jobs/test-job"]
-        assert len(params) == 2
-        assert params[0] == {"name": "item1", "value": "100"}
-        assert params[1] == {"name": "item2", "value": "200"}
-        assert image is None
-    finally:
-        os.unlink(workflow_path)
-        os.unlink(params_path)
+    workflow_path = str(tmpdir.join("workflow.json"))
+    create_workflow_file(workflow_path, workflow_def)
 
-def test_run_workflow_with_variable_expansion():
+    sparkles = MockSparkles()
+    sparkles.get_job_path_prefix = lambda: "/path/to/jobs"
+    job_name = "test-job"
+    
+    # Run the workflow
+    run_workflow(sparkles, job_name, workflow_path, False)
+    
+    # Verify the expected calls were made
+    assert sparkles.job_exists_calls == ["test-job-1"]
+    assert len(sparkles.start_calls) == 1
+    name, command, params, image = sparkles.start_calls[0]
+    assert name == "test-job-1"
+    assert command == ["process", "test-job", "/path/to/jobs/test-job"]
+    assert len(params) == 2
+    assert params[0] == {"name": "item1", "value": "100"}
+    assert params[1] == {"name": "item2", "value": "200"}
+    assert image is None
+
+def test_run_workflow_with_variable_expansion(tmpdir):
     # Create a workflow definition with variables to expand
     workflow_def = {
         "steps": [
@@ -149,20 +143,19 @@ def test_run_workflow_with_variable_expansion():
         ]
     }
     
-    workflow_path = create_workflow_file(workflow_def)
-    try:
-        sparkles = MockSparkles()
-        job_name = "test-job"
-        
-        # Mock the _get_var function to return a value for step1_output
-        with patch('sparklespray.workflow._expand_template', side_effect=lambda val, _: val.replace("{step1_output}", "expanded value")):
-            # Run the workflow
-            run_workflow(sparkles, job_name, workflow_path, False)
-        
-        # Verify the expected calls were made
-        assert sparkles.job_exists_calls == ["test-job-1", "test-job-2"]
-        assert len(sparkles.start_calls) == 2
-        assert sparkles.start_calls[0][1] == ["echo", "First step"]
-        assert sparkles.start_calls[1][1] == ["echo", "expanded value"]
-    finally:
-        os.unlink(workflow_path)
+    workflow_path = str(tmpdir.join("workflow.json"))
+    create_workflow_file(workflow_path, workflow_def)
+
+    sparkles = MockSparkles()
+    job_name = "test-job"
+    
+    # Mock the _get_var function to return a value for step1_output
+    with patch('sparklespray.workflow._expand_template', side_effect=lambda val, _: val.replace("{step1_output}", "expanded value")):
+        # Run the workflow
+        run_workflow(sparkles, job_name, workflow_path, False)
+    
+    # Verify the expected calls were made
+    assert sparkles.job_exists_calls == ["test-job-1", "test-job-2"]
+    assert len(sparkles.start_calls) == 2
+    assert sparkles.start_calls[0][1] == ["echo", "First step"]
+    assert sparkles.start_calls[1][1] == ["echo", "expanded value"]

--- a/cli/tests/sparklespray/workflow_test.py
+++ b/cli/tests/sparklespray/workflow_test.py
@@ -129,33 +129,3 @@ def test_run_workflow_with_parameters(tmpdir):
     assert params[0] == {"name": "item1", "value": "100"}
     assert params[1] == {"name": "item2", "value": "200"}
     assert image is None
-
-def test_run_workflow_with_variable_expansion(tmpdir):
-    # Create a workflow definition with variables to expand
-    workflow_def = {
-        "steps": [
-            {
-                "command": ["echo", "First step"],
-            },
-            {
-                "command": ["echo", "{step1_output}"],
-            }
-        ]
-    }
-    
-    workflow_path = str(tmpdir.join("workflow.json"))
-    create_workflow_file(workflow_path, workflow_def)
-
-    sparkles = MockSparkles()
-    job_name = "test-job"
-    
-    # Mock the _get_var function to return a value for step1_output
-    with patch('sparklespray.workflow._expand_template', side_effect=lambda val, _: val.replace("{step1_output}", "expanded value")):
-        # Run the workflow
-        run_workflow(sparkles, job_name, workflow_path, False)
-    
-    # Verify the expected calls were made
-    assert sparkles.job_exists_calls == ["test-job-1", "test-job-2"]
-    assert len(sparkles.start_calls) == 2
-    assert sparkles.start_calls[0][1] == ["echo", "First step"]
-    assert sparkles.start_calls[1][1] == ["echo", "expanded value"]

--- a/examples/workflow-1/gather.sh
+++ b/examples/workflow-1/gather.sh
@@ -1,0 +1,4 @@
+fruit_paths=`gcloud storage ls "$1/*/fruit.txt"`
+for ii in $fruit_paths; do
+    gcloud storage cat $ii >> merged_list.txt
+done

--- a/examples/workflow-1/make_params.sh
+++ b/examples/workflow-1/make_params.sh
@@ -1,0 +1,5 @@
+cat > params.csv <<EOF
+index,fruit
+0,apple
+1,banana
+EOF

--- a/examples/workflow-1/scatter-gather.json
+++ b/examples/workflow-1/scatter-gather.json
@@ -1,0 +1,20 @@
+{
+  "steps": [
+    {
+      "command": ["sh", "./make_params.sh"],
+      "image": "ubuntu:latest",
+      "files_to_localize": ["make_params.sh"]
+    },
+    {
+      "parameters_csv": "{prev_job_path}/1/params.csv",
+      "image": "ubuntu:latest",
+      "command": ["sh", "worker.sh", "{parameter.index}", "{parameter.fruit}"],
+      "files_to_localize": ["worker.sh"]
+    },
+    {
+      "command": ["sh", "./gather.sh", "{prev_job_path}"],
+      "image": "google/cloud-sdk:latest",
+      "files_to_localize": ["gather.sh"]
+    }
+  ]
+}

--- a/examples/workflow-1/worker.sh
+++ b/examples/workflow-1/worker.sh
@@ -1,0 +1,2 @@
+echo running $1
+echo $2 > fruit.txt


### PR DESCRIPTION
Added the `sparkles workflow run ...` command which allows a sequence of jobs to be run. In particular, useful for running simple scatter-gather type workflows. 

See `examples/workflow-1` for a toy example
